### PR TITLE
Fixing runtime errors

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -83,8 +83,8 @@ class App extends Component {
     return (
       <div className="App">
         <div className="App-header">
-          <div class="Heading-text">Timeline</div>
-          <div class="Login-button">
+          <div className="Heading-text">Timeline</div>
+          <div className="Login-button">
             {this.state.user ?
               <button onClick={this.logout}>Log Out</button>
               :


### PR DESCRIPTION
React doesn't like 'div class' as much as it likes 'div className'.

These snuck in by accident (wasn't paying enough attention to the naming of similar elements) in PR #82 