### PR TITLE
Hide/display New Encounter form

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -37,6 +37,11 @@
   to { transform: rotate(360deg); }
 }
 
+/* NewEncounter component */
+.NewEncounter {
+  display: none;
+}
+
 /* Encounter component */
 
 .Encounter-data {

--- a/src/App.css
+++ b/src/App.css
@@ -20,6 +20,10 @@
   font-size: 28px;
 }
 
+.New-encounter-button {
+  float:left;
+}
+
 .Login-button {
   float: right;
 }

--- a/src/App.js
+++ b/src/App.js
@@ -83,7 +83,10 @@ class App extends Component {
     return (
       <div className="App">
         <div className="App-header">
-          <div class="Heading-text">Timeline</div>
+        <div class="Heading-text">Timeline</div>
+          <div class="New-encounter-button">
+            <button>New</button>
+          </div>
           <div class="Login-button">
             {this.state.user ?
               <button onClick={this.logout}>Log Out</button>

--- a/src/App.js
+++ b/src/App.js
@@ -17,6 +17,7 @@ class App extends Component {
     }
     this.login = this.login.bind(this);
     this.logout = this.logout.bind(this);
+    this.showNew = this.showNew.bind(this);
   }
 
   componentDidMount() {
@@ -79,13 +80,19 @@ class App extends Component {
       });
   }
 
+  showNew() {
+    // Show the New Encounter form
+    // either display the inline Component or pop up a "portal": https://stackoverflow.com/a/45291662
+
+  }
+
   render() {
     return (
       <div className="App">
         <div className="App-header">
         <div class="Heading-text">Timeline</div>
           <div class="New-encounter-button">
-            <button>New</button>
+            <button onClick={this.showNew}>New</button>
           </div>
           <div class="Login-button">
             {this.state.user ?

--- a/src/App.js
+++ b/src/App.js
@@ -90,8 +90,8 @@ class App extends Component {
     return (
       <div className="App">
         <div className="App-header">
-        <div class="Heading-text">Timeline</div>
-          <div class="New-encounter-button">
+        <div className="Heading-text">Timeline</div>
+          <div className="New-encounter-button">
             <button onClick={this.showNew}>New</button>
           </div>
           <div class="Login-button">

--- a/src/App.js
+++ b/src/App.js
@@ -83,7 +83,8 @@ class App extends Component {
   showNew() {
     // Show the New Encounter form
     // either display the inline Component or pop up a "portal": https://stackoverflow.com/a/45291662
-    
+    document.getElementById("new-form").style.display = "inline";
+    console.log("showNew() has fired")
   }
 
   render() {
@@ -104,7 +105,7 @@ class App extends Component {
         </div>
         {this.state.user ?
           <div className="wrapper">
-            <div className="NewEncounter">
+            <div id="new-form" className="NewEncounter">
               <NewEncounter db={firebase}/>
             </div>
             <div className="Timeline">

--- a/src/App.js
+++ b/src/App.js
@@ -83,7 +83,7 @@ class App extends Component {
   showNew() {
     // Show the New Encounter form
     // either display the inline Component or pop up a "portal": https://stackoverflow.com/a/45291662
-
+    
   }
 
   render() {
@@ -94,7 +94,7 @@ class App extends Component {
           <div className="New-encounter-button">
             <button onClick={this.showNew}>New</button>
           </div>
-          <div class="Login-button">
+          <div className="Login-button">
             {this.state.user ?
               <button onClick={this.logout}>Log Out</button>
               :

--- a/src/components/NewEncounter.js
+++ b/src/components/NewEncounter.js
@@ -46,6 +46,7 @@ class NewEncounter extends Component {
       location: '',
       topics: ''
     })
+    document.getElementById("new-form").style.display = "none";
   }
 
   render() {


### PR DESCRIPTION
New Encounter form is always displayed on the Timeline.

I want to hide the New Encounter form when I'm simply browsing the Timeline (which is arguably the most common usage of this app).

Resolves #22 and #40.