### PR TITLE
Replace airbnb with eslint:recommended rules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,18 @@
+{
+    "extends": "eslint:recommended",
+    "env": {
+      "browser": true,
+      "commonjs": true,
+      "node": true,
+      "es6": true
+    },
+    "parserOptions": {
+      "ecmaVersion": 6
+    },
+    "rules": {
+      "no-console": "off",
+      "strict": ["error", "global"],
+      "curly": "warn",
+      "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }]
+    }
+}

--- a/.eslintrc
+++ b/.eslintrc
@@ -7,7 +7,8 @@
       "es6": true
     },
     "parserOptions": {
-      "ecmaVersion": 6
+      "ecmaVersion": 6,
+      "sourceType": "module"
     },
     "rules": {
       "no-console": "off",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,9 +1,0 @@
-{
-    "extends": "airbnb",
-    "env": {
-        "browser": true
-    },
-    "rules": {
-        "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }]
-    }
-}


### PR DESCRIPTION
Airbnb styles are [not recommended by the React development team](https://www.reddit.com/r/reactjs/comments/7ls6y0/what_confused_you_the_most_when_starting_to_learn/drp7dhz/?sh=9b63c914&st=JBL2AGAQ).

Switching to the "recommended" rules in the official `eslint` package.  This seems a much saner starting place.