### PR TITLE
Enabled babel-eslint package as parser

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,9 @@
 {
-    "extends": "eslint:recommended",
+  "parser": "babel-eslint",
+  "plugins": [
+    "react"
+  ],
+  "extends": "eslint:recommended",
     "env": {
       "browser": true,
       "commonjs": true,

--- a/.eslintrc
+++ b/.eslintrc
@@ -3,7 +3,7 @@
   "plugins": [
     "react"
   ],
-  "extends": "eslint:recommended",
+  "extends": ["eslint:recommended", "plugin:react/recommended"],
     "env": {
       "browser": true,
       "commonjs": true,

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     ]
   },
   "devDependencies": {
+    "babel-eslint": "^8.1.2",
     "eslint": "^4.14.0",
     "eslint-config-airbnb": "^16.1.0",
     "eslint-plugin-import": "2.7.0",

--- a/src/App.js
+++ b/src/App.js
@@ -123,7 +123,7 @@ class App extends Component {
           </div>
         ) : (
           <div className="wrapper">
-            <p>Unless you're logged in, you don't get to see the data</p>
+            <p>Unless you are logged in, you and the data shall never meet</p>
           </div>
         )}
       </div>

--- a/src/components/Encounter.js
+++ b/src/components/Encounter.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { Grid, Col, Row } from 'react-bootstrap';
 import PropTypes from 'prop-types';
 
-const Encounter = props => {
+const Encounter = (props) => {
   return (
     <div className="encounter">
       <Grid>
@@ -13,22 +13,22 @@ const Encounter = props => {
                 <img src={props.Photo} alt="" />
               </div>
             </Col>
-              <Col xs={5}>
-                <Row>
-                  <div className="person-name">{props.Person}</div>
-                </Row>
-                <Row>
-                  <div className="encounter-date">{props.Date}</div>
-                </Row>
-              </Col>
-              <Col xs={5}>
-                <Row>
-                  <div className="encounter-event">{props.Event}</div>
-                </Row>
-                <Row>
-                  <div className="encounter-location">{props.Location}</div>
-                </Row>
-              </Col>
+            <Col xs={5}>
+              <Row>
+                <div className="person-name">{props.Person}</div>
+              </Row>
+              <Row>
+                <div className="encounter-date">{props.Date}</div>
+              </Row>
+            </Col>
+            <Col xs={5}>
+              <Row>
+                <div className="encounter-event">{props.Event}</div>
+              </Row>
+              <Row>
+                <div className="encounter-location">{props.Location}</div>
+              </Row>
+            </Col>
           </Row>
           <Row>
             <div className="encounter-topics">Topics: {props.Topics}</div>
@@ -46,6 +46,7 @@ Encounter.propTypes = {
   Date: PropTypes.string.isRequired,
   Event: PropTypes.string,
   Location: PropTypes.string,
+  Topics: PropTypes.string,
 };
 
 Encounter.defaultProps = {

--- a/src/components/NewEncounter.js
+++ b/src/components/NewEncounter.js
@@ -1,14 +1,15 @@
 import React, { Component } from 'react';
-import { Col, Row} from 'react-bootstrap';
+import { Col, Row } from 'react-bootstrap';
+import PropTypes from 'prop-types';
 
 class NewEncounter extends Component {
   state = {
-  fullname: '',
-  date: '',
-  event: '',
-  location: '',
-  topics: ''
-  }
+    fullname: '',
+    date: '',
+    event: '',
+    location: '',
+    topics: '',
+  };
 
   /* TODO: research why initializing state variables doesn't have to be in the constructor(), 
      and if the same trick works for binding this in the constructor */
@@ -25,30 +26,32 @@ class NewEncounter extends Component {
        and sets the state variable with the same name
        to the value of the input submitted so far by the time this event fires */
     this.setState({
-      [e.target.name]: e.target.value
+      [e.target.name]: e.target.value,
     });
   }
 
   handleSubmit(e) {
     e.preventDefault();
-    const itemsRef = this.props.db.database().ref('encounters/' + this.props.db.auth().currentUser.uid);
+    const itemsRef = this.props.db
+      .database()
+      .ref('encounters/' + this.props.db.auth().currentUser.uid);
     // record to be pushed has key-value pairs of "name of firebase field": "value of that field"
     const item = {
       Person: this.state.fullname,
       Date: this.state.date,
       Event: this.state.event,
       Location: this.state.location,
-      Topics: this.state.topics
-    }
+      Topics: this.state.topics,
+    };
     itemsRef.push(item);
     this.setState({
       fullname: '',
       date: '',
       event: '',
       location: '',
-      topics: ''
-    })
-    document.getElementById("new-form").style.display = "none";
+      topics: '',
+    });
+    document.getElementById('new-form').style.display = 'none';
   }
 
   render() {
@@ -56,47 +59,71 @@ class NewEncounter extends Component {
       <form onSubmit={this.handleSubmit}>
         <Col>
           <Row>
-            <input type="text" 
-                  name="fullname"
-                  placeholder="What's their full name?"
-                  onChange={this.handleChange}
-                  value={this.state.fullname} /* without this, textbox doesn't clear on submit */ />
+            <input
+              type="text"
+              name="fullname"
+              placeholder="What's their full name?"
+              onChange={this.handleChange}
+              value={
+                this.state.fullname
+              } /* without this, textbox doesn't clear on submit */
+            />
           </Row>
           <Row>
-            <input type="date" 
-                  name="date"
-                  placeholder="When did you meet?"
-                  onChange={this.handleChange}
-                  value={this.state.date} /* without this, textbox doesn't clear on submit */ />
+            <input
+              type="date"
+              name="date"
+              placeholder="When did you meet?"
+              onChange={this.handleChange}
+              value={
+                this.state.date
+              } /* without this, textbox doesn't clear on submit */
+            />
           </Row>
           <Row>
-            <input type="text" 
-                  name="event"
-                  placeholder="At what event (optional)?"
-                  onChange={this.handleChange}
-                  value={this.state.event} /* without this, textbox doesn't clear on submit */ />
+            <input
+              type="text"
+              name="event"
+              placeholder="At what event (optional)?"
+              onChange={this.handleChange}
+              value={
+                this.state.event
+              } /* without this, textbox doesn't clear on submit */
+            />
           </Row>
           <Row>
-            <input type="text" 
-                  name="location"
-                  placeholder="At what place (optional)?"
-                  onChange={this.handleChange}
-                  value={this.state.location} /* without this, textbox doesn't clear on submit */ />
+            <input
+              type="text"
+              name="location"
+              placeholder="At what place (optional)?"
+              onChange={this.handleChange}
+              value={
+                this.state.location
+              } /* without this, textbox doesn't clear on submit */
+            />
           </Row>
           <Row>
-            <textarea rows="3"
-                  name="topics"
-                  placeholder="What did you talk about (optional)?"
-                  onChange={this.handleChange}
-                  value={this.state.topics} /* without this, textbox doesn't clear on submit */ />
+            <textarea
+              rows="3"
+              name="topics"
+              placeholder="What did you talk about (optional)?"
+              onChange={this.handleChange}
+              value={
+                this.state.topics
+              } /* without this, textbox doesn't clear on submit */
+            />
           </Row>
           <Row>
             <button>Add Encounter</button>
           </Row>
         </Col>
       </form>
-    )
+    );
   }
 }
 
-export default NewEncounter
+NewEncounter.propTypes = {
+  db: PropTypes.object.isRequired,
+};
+
+export default NewEncounter;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,59 @@
 # yarn lockfile v1
 
 
+"@babel/code-frame@7.0.0-beta.31":
+  version "7.0.0-beta.31"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0-beta.31.tgz#473d021ecc573a2cce1c07d5b509d5215f46ba35"
+  dependencies:
+    chalk "^2.0.0"
+    esutils "^2.0.2"
+    js-tokens "^3.0.0"
+
+"@babel/helper-function-name@7.0.0-beta.31":
+  version "7.0.0-beta.31"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.31.tgz#afe63ad799209989348b1109b44feb66aa245f57"
+  dependencies:
+    "@babel/helper-get-function-arity" "7.0.0-beta.31"
+    "@babel/template" "7.0.0-beta.31"
+    "@babel/traverse" "7.0.0-beta.31"
+    "@babel/types" "7.0.0-beta.31"
+
+"@babel/helper-get-function-arity@7.0.0-beta.31":
+  version "7.0.0-beta.31"
+  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.31.tgz#1176d79252741218e0aec872ada07efb2b37a493"
+  dependencies:
+    "@babel/types" "7.0.0-beta.31"
+
+"@babel/template@7.0.0-beta.31":
+  version "7.0.0-beta.31"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.0.0-beta.31.tgz#577bb29389f6c497c3e7d014617e7d6713f68bda"
+  dependencies:
+    "@babel/code-frame" "7.0.0-beta.31"
+    "@babel/types" "7.0.0-beta.31"
+    babylon "7.0.0-beta.31"
+    lodash "^4.2.0"
+
+"@babel/traverse@7.0.0-beta.31":
+  version "7.0.0-beta.31"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.0.0-beta.31.tgz#db399499ad74aefda014f0c10321ab255134b1df"
+  dependencies:
+    "@babel/code-frame" "7.0.0-beta.31"
+    "@babel/helper-function-name" "7.0.0-beta.31"
+    "@babel/types" "7.0.0-beta.31"
+    babylon "7.0.0-beta.31"
+    debug "^3.0.1"
+    globals "^10.0.0"
+    invariant "^2.2.0"
+    lodash "^4.2.0"
+
+"@babel/types@7.0.0-beta.31":
+  version "7.0.0-beta.31"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.0.0-beta.31.tgz#42c9c86784f674c173fb21882ca9643334029de4"
+  dependencies:
+    esutils "^2.0.2"
+    lodash "^4.2.0"
+    to-fast-properties "^2.0.0"
+
 "@firebase/app@^0.1.3":
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/@firebase/app/-/app-0.1.3.tgz#4bebeadb18426d44de8899cd6c37a9a1aaccc62c"
@@ -447,6 +500,17 @@ babel-eslint@7.2.3:
     babel-traverse "^6.23.1"
     babel-types "^6.23.0"
     babylon "^6.17.0"
+
+babel-eslint@^8.1.2:
+  version "8.1.2"
+  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-8.1.2.tgz#a39230b0c20ecbaa19a35d5633bf9b9ca2c8116f"
+  dependencies:
+    "@babel/code-frame" "7.0.0-beta.31"
+    "@babel/traverse" "7.0.0-beta.31"
+    "@babel/types" "7.0.0-beta.31"
+    babylon "7.0.0-beta.31"
+    eslint-scope "~3.7.1"
+    eslint-visitor-keys "^1.0.0"
 
 babel-generator@^6.18.0, babel-generator@^6.26.0:
   version "6.26.0"
@@ -1036,6 +1100,10 @@ babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.23.0, babel-types@^6.24
     esutils "^2.0.2"
     lodash "^4.17.4"
     to-fast-properties "^1.0.3"
+
+babylon@7.0.0-beta.31:
+  version "7.0.0-beta.31"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.31.tgz#7ec10f81e0e456fd0f855ad60fa30c2ac454283f"
 
 babylon@^6.17.0, babylon@^6.18.0:
   version "6.18.0"
@@ -2494,7 +2562,7 @@ eslint-restricted-globals@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/eslint-restricted-globals/-/eslint-restricted-globals-0.1.1.tgz#35f0d5cbc64c2e3ed62e93b4b1a7af05ba7ed4d7"
 
-eslint-scope@^3.7.1:
+eslint-scope@^3.7.1, eslint-scope@~3.7.1:
   version "3.7.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-3.7.1.tgz#3d63c3edfda02e06e01a452ad88caacc7cdcb6e8"
   dependencies:
@@ -3199,6 +3267,10 @@ global-prefix@^1.0.1:
     is-windows "^1.0.1"
     which "^1.2.14"
 
+globals@^10.0.0:
+  version "10.4.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-10.4.0.tgz#5c477388b128a9e4c5c5d01c7a2aca68c68b2da7"
+
 globals@^11.0.1:
   version "11.1.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.1.0.tgz#632644457f5f0e3ae711807183700ebf2e4633e4"
@@ -3647,7 +3719,7 @@ interpret@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.1.0.tgz#7ed1b1410c6a0e0f78cf95d3b8440c63f78b8614"
 
-invariant@^2.1.0, invariant@^2.2.1, invariant@^2.2.2:
+invariant@^2.1.0, invariant@^2.2.0, invariant@^2.2.1, invariant@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.2.tgz#9e1f56ac0acdb6bf303306f338be3b204ae60360"
   dependencies:
@@ -4565,7 +4637,7 @@ lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
 
-"lodash@>=3.5 <5", lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.3.0:
+"lodash@>=3.5 <5", lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -7004,6 +7076,10 @@ to-arraybuffer@^1.0.0:
 to-fast-properties@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
+
+to-fast-properties@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz#dc5e698cbd079265bc73e0377681a4e4e83f616e"
 
 toposort@^1.0.0:
   version "1.0.6"


### PR DESCRIPTION
To address the remaining eslint errors and warnings from #95 - (1), (5) and (6) - we enabled `babel-eslint` as the default parser for `eslint`.

However this created its own set of errors and warnings, requiring additional help:
- explicitly adding eslint-plugin-react as a plugin in `.eslintrc` addressed react/jsx-filename-extension warning
- adding "plugin:react/recommended" to the "extends" configuration addressed the no-unused-vars issue (aka "[Component] is defined but never used") - per https://github.com/eslint/eslint/issues/3622#issuecomment-221885333

The addition of "react:recommended" rules threw off a few new warnings - but this time, they were legitimate misses that I'm glad the linter caught for me.
